### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Miraheze TSPortal
 
-Miraheze TSPortal is the platform Miraheze is transitioning over to use as its in-house built platform for handling reports, investigations, appeals and transparency.
+TSPortal is the platform Miraheze uses as its in-house built platform for handling reports, investigations, appeals, and transparency.
 
 It is designed by [Owen Baines](https://github.com/OwenBaines) and is managed on [Phabricator](https://phabricator.miraheze.org/project/board/71/).
 
@@ -8,12 +8,12 @@ This software is built on the [Laravel](https://laravel.com) framework, released
 
 ## Code of Conduct
 
-In order to ensure that the community is welcoming to all, please review and abide by the [Code of Conduct](https://meta.miraheze.org/wiki/Code_of_Conduct).
+In order to ensure that the community is welcoming to all, please review and abide by the [Code of Conduct](https://meta.miraheze.org/wiki/Special:MyLanguage/Code_of_Conduct).
 
 ## Security Vulnerabilities
 
-Please review [our security policy](https://meta.miraheze.org/wiki/Security) on how to report security vulnerabilities.
+Please review [our security policy](https://meta.miraheze.org/wiki/Special:MyLanguage/Security) on how to report security vulnerabilities.
 
 ## License
 
-This software is open-sourced software licensed under the [MIT license](LICENSE.md).
+This is open-sourced software licensed under the [MIT license](LICENSE.md).


### PR DESCRIPTION
* Remove one mention of "Miraheze", so instead of "Miraheze TSPortal is the platform Miraheze uses", remove the first instance of "Miraheze" as the second instance (and header) clearly defines that it is the Miraheze TSPortal. Both instances seem redundant to me, and this makes more grammatical sense in my opinion.
  * Also does this for a double instance of "Software" under "Licensing" for the same reason.
* Mention that Miraheze uses TSPortal, as it is not transitioning anymore, it is used.
* Use Special:MyLanguage links for "Code of Conduct" and "Security" pages.